### PR TITLE
fix: change job step to use diff instead of breakdown

### DIFF
--- a/.github/workflows/infracost-pr-compare-to-called.yml
+++ b/.github/workflows/infracost-pr-compare-to-called.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Infracost on PR Branch
         run: >-
-          infracost breakdown
+          infracost diff
           --path ${{ inputs.path }}
           --terraform-plan-flags ${{ inputs.terraform_plan_flags }} ${{ secrets.terraform_secret_plan_flags }}
           --terraform-parse-hcl


### PR DESCRIPTION
Hi @brettcurtis , I'm just making this change as we're actually modifying the interface for `--compare-to`. It's now exclusive to the `diff` command. This will be released as part of the `0.9.24` release. 

We realised that having `--compare-to` on `breakdown` didn't make sense so we removed it and wanted to get a fix out ASAP. Technically this should be a `0.10` release as it's a breaking change, but because it's so recent we wanted to push it and reach out directly to users who are using the old method. I've added the necessary changes here as I see you were in the process of migrating your other repos to use these composable workflows.

I'll message you here when the `0.9.24` release is actually published and this is good to merge. Thanks for being patient with us!